### PR TITLE
ignore db folder and Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+db
+Gemfile.lock


### PR DESCRIPTION
`bundle install` 수행 시 생성되는 `Gemfile.lock`, `ruby BibleCroller.rb` 수행 시 생성되는 `db` folder를 ignore했어요.